### PR TITLE
Base command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,14 @@ build-all:
 .PHONY: test
 test:
 	@echo "Running tests..."
-	sudo go test -v -race ./...
+	go test -v -race ./...
 	@echo "✓ All tests passed!"
 
 # Run tests with coverage (needs sudo for E2E tests)
 .PHONY: test-coverage
 test-coverage:
 	@echo "Running tests with coverage..."
-	sudo go test -v -race -coverprofile=coverage.out ./...
+	go test -v -race -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "✓ Coverage report generated: coverage.html"
 


### PR DESCRIPTION
This separates out a base serpent command form the top level command for jail so it can be used as a subcommand without creating sources of drift. In coder, we'll just use the base command directly.