### PR TITLE
refactor: remove commented out code

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -315,22 +315,6 @@ func (p *Server) forwardRequest(conn net.Conn, req *http.Request, https bool) {
 		RawQuery: req.URL.RawQuery,
 	}
 
-	//var requestBodyBytes []byte
-	//{
-	//	var err error
-	//	requestBodyBytes, err = io.ReadAll(req.Body)
-	//	if err != nil {
-	//		p.logger.Error("can't read response body", "error", err)
-	//		return
-	//	}
-	//	err = req.Body.Close()
-	//	if err != nil {
-	//		p.logger.Error("Failed to close HTTP response body", "error", err)
-	//		return
-	//	}
-	//	req.Body = io.NopCloser(bytes.NewBuffer(requestBodyBytes))
-	//}
-
 	var body = req.Body
 	if req.Method == http.MethodGet || req.Method == http.MethodHead {
 		body = nil
@@ -364,12 +348,8 @@ func (p *Server) forwardRequest(conn net.Conn, req *http.Request, https bool) {
 	p.logger.Debug("Forwarded Request",
 		"method", newReq.Method,
 		"host", newReq.Host,
-		//"requestBodyBytes", string(requestBodyBytes),
 		"URL", newReq.URL,
 	)
-	//for hKey, hVal := range newReq.Header {
-	//	p.logger.Debug("Forwarded Request Header", hKey, hVal)
-	//}
 
 	// Read the body and explicitly set Content-Length header, otherwise client can hung up on the request.
 	bodyBytes, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
I found this commented out code while digging through boundary. We should remove it.