### PR TITLE
chore: allow manual ci workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
This will allow us to run the CI workflow manually for a particular branch. I sometimes use this for changes to gain confidence in CI tests before opening a PR.