### PR TITLE
feat: restrict UDP communications

### DIFF
--- a/e2e_tests/nsjail/ns_jail_framework_test.go
+++ b/e2e_tests/nsjail/ns_jail_framework_test.go
@@ -209,6 +209,18 @@ func (nt *NSJailTest) ExpectDenyContains(url string, containsText string) {
 	require.Contains(nt.t, string(output), containsText, "Response does not contain expected denial text")
 }
 
+// sendUDP sends a UDP packet from inside the namespace to the given address:port
+func (nt *NSJailTest) sendUDP(addr string, port int, message string) error {
+	nt.t.Helper()
+
+	pid := fmt.Sprintf("%v", nt.pid)
+	args := []string{"nsenter", "-t", pid, "-n", "--",
+		"sh", "-c", fmt.Sprintf("echo '%s' | nc -u -w 1 %s %d", message, addr, port)}
+
+	cmd := exec.Command("sudo", args...)
+	return cmd.Run()
+}
+
 // getTargetProcessPID gets the PID of the boundary target process.
 // Target process is associated with a network namespace, so you can exec into it, using this PID.
 // pgrep -f boundary-test -n is doing two things:


### PR DESCRIPTION
Closes https://github.com/coder/boundary/issues/149

# Restrict UDP communications in network namespace

## Summary

This PR adds iptables rules to restrict UDP traffic in the network namespace, allowing only UDP to/from loopback (for dummy DNS) and blocking all other UDP communications. This prevents UDP-based exfiltration and limits the attack surface by blocking non-DNS UDP protocols (NTP, custom protocols, etc.).

## Changes

### UDP Restriction Rules

Added iptables filter rules in `StartDummyDNSAndRedirect()` to restrict UDP traffic:

1. **Allow UDP to loopback** (`-d 127.0.0.1`) - Permits UDP packets destined for 127.0.0.1 (dummy DNS queries after DNAT)
2. **Allow UDP from loopback** (`-s 127.0.0.1`) - Permits UDP packets originating from 127.0.0.1 (dummy DNS replies to clients)
3. **Drop all other UDP** - Blocks all UDP traffic that doesn't match the above rules

### Implementation Details

- Rules are added in the **filter table OUTPUT chain** inside the network namespace
- Applied only when dummy DNS is enabled (inside `StartDummyDNSAndRedirect`)
- DNS continues to work: UDP port 53 is DNAT'd to 127.0.0.1:5353, then matches the "UDP to loopback" rule
- All other UDP (NTP, custom protocols, exfiltration on arbitrary ports) is blocked

### Testing

Added `TestUDPBlocking` e2e test that verifies:
- UDP to non-DNS ports is blocked (packets don't reach the host)
- DNS still works correctly (UDP port 53 returns dummy IP)

## Security Impact

**Before:** All UDP traffic was allowed, enabling potential exfiltration via:
- Custom UDP protocols on arbitrary ports
- NTP (port 123)
- DNS over non-standard ports
- Any UDP-based data exfiltration

**After:** Only DNS (via dummy DNS server on loopback) is allowed. All other UDP is blocked, significantly reducing the attack surface.

## Behavior

**With dummy DNS (default):**
- DNS queries work (UDP port 53 → DNAT → dummy DNS on 127.0.0.1:5353)
- All other UDP is blocked

**With `--use-real-dns`:**
- UDP restriction rules are not applied (dummy DNS setup is skipped)
- All UDP traffic is allowed (including real DNS and other protocols)

## Related

Builds on PR #164 (dummy DNS implementation). This PR adds UDP restriction on top of the dummy DNS to further harden the network namespace.