### PR TITLE
feat(boundary): generate session ID at startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,11 @@ type AppConfig struct {
 	UserInfo           *UserInfo
 	DisableAuditLogs   bool
 	LogProxySocketPath string
+
+	// SessionID is a UUIDv4 generated at process startup. It groups
+	// all audit events produced by this boundary invocation into a
+	// single session. Set by Run, not by configuration.
+	SessionID string
 }
 
 func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coder/coder/v2 v2.10.1-0.20260303212958-f758443f44ac
 	github.com/coder/serpent v0.14.0
+	github.com/google/uuid v1.6.0
 	github.com/landlock-lsm/go-landlock v0.0.0-20251103212306-430f8e5cd97c
 	github.com/miekg/dns v1.1.72
 	github.com/spf13/pflag v1.0.10

--- a/run/run_linux.go
+++ b/run/run_linux.go
@@ -10,9 +10,13 @@ import (
 	"github.com/coder/boundary/config"
 	"github.com/coder/boundary/landjail"
 	"github.com/coder/boundary/nsjail_manager"
+	"github.com/google/uuid"
 )
 
 func Run(ctx context.Context, logger *slog.Logger, cfg config.AppConfig) error {
+	cfg.SessionID = uuid.New().String()
+	logger.Info("boundary session started", "session_id", cfg.SessionID)
+
 	switch cfg.JailType {
 	case config.NSJailType:
 		return nsjail_manager.Run(ctx, logger, cfg)


### PR DESCRIPTION
## PR Map

1. 👉🏼 **#194** (closed — merged into #196)
2. #195 (closed — merged into #196)
3. #196
4. #197
5. #198

---

Adds a `SessionID` field to `config.AppConfig` and generates a UUIDv4 at the
top of `Run` in `run_linux.go`. The ID is logged once at startup. No consumers
yet.

This is the first step of the session correlation RFC: every boundary
invocation gets a stable identity that future work will attach to audit events
and communicate to Bridge.

## Changes

- **`config/config.go`**: Add `SessionID string` to `AppConfig`.
- **`run/run_linux.go`**: Generate UUID and log it before dispatching to the
  jail-specific runner.
- **`go.mod`**: Promote `github.com/google/uuid` from indirect to direct
  dependency.

The stub (`run_stub.go`) is unchanged; it returns an error immediately on
non-Linux platforms, so there is no session to start.

> Generated by Coder Agents