### PR TITLE
feat(config): session correlation header injection configuration

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -39,11 +39,11 @@ func NewCommand(version string) *serpent.Command {
 
   # Block everything by default (implicit)
 
-  # Enable session correlation inside a Coder workspace (inject target auto-derived from CODER_AGENT_URL)
+  # Enable session correlation inside a Coder workspace
   boundary --enable-session-correlation \
     --allow "domain=dev.coder.com" -- python train.py
 
-  # Enable session correlation with an explicit inject target (e.g. outside a workspace or custom deployment)
+  # Enable session correlation with an explicit inject target
   boundary --enable-session-correlation \
     --session-id-inject-target "domain=mydeployment.coder.com path=/api/v2/aibridge/*" \
     --allow "domain=mydeployment.coder.com" -- python train.py

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -228,7 +228,7 @@ func BaseCommand(version string) *serpent.Command {
 				printVersion(version)
 				return nil
 			}
-			appConfig, err := config.NewAppConfigFromCliConfig(cliConfig, inv.Args)
+			appConfig, err := config.NewAppConfigFromCliConfig(cliConfig, inv.Args, os.Environ())
 			if err != nil {
 				return fmt.Errorf("failed to parse cli config file: %v", err)
 			}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -37,7 +37,22 @@ func NewCommand(version string) *serpent.Command {
   # Use allowlist from config file with additional CLI allow rules
   boundary --allow "domain=example.com" -- curl https://example.com
 
-  # Block everything by default (implicit)`
+  # Block everything by default (implicit)
+
+  # Enable session correlation inside a Coder workspace (inject target auto-derived from CODER_AGENT_URL)
+  boundary --enable-session-correlation \
+    --allow "domain=dev.coder.com" -- python train.py
+
+  # Enable session correlation with an explicit inject target (e.g. outside a workspace or custom deployment)
+  boundary --enable-session-correlation \
+    --session-id-inject-target "domain=mydeployment.coder.com path=/api/v2/aibridge/*" \
+    --allow "domain=mydeployment.coder.com" -- python train.py
+
+  # Enable session correlation with multiple inject targets (e.g. staging + prod)
+  boundary --enable-session-correlation \
+    --session-id-inject-target "domain=staging.coder.com path=/api/v2/aibridge/*" \
+    --session-id-inject-target "domain=prod.coder.com path=/api/v2/aibridge/*" \
+    --allow "domain=staging.coder.com" --allow "domain=prod.coder.com" -- python train.py`
 
 	return cmd
 }
@@ -173,21 +188,21 @@ func BaseCommand(version string) *serpent.Command {
 			{
 				Flag:        "enable-session-correlation",
 				Env:         "BOUNDARY_SESSION_CORRELATION_ENABLED",
-				Description: "Enable session correlation header injection. Disable for deployments without AI Bridge in front.",
+				Description: "Enable session correlation header injection. When no inject targets are configured, the target is auto-derived from CODER_AGENT_URL (set automatically inside Coder workspaces). Disable for deployments without Coder AI Gateway in front.",
 				Value:       &cliConfig.SessionCorrelationEnabled,
 				YAML:        "session_correlation_enabled",
 			},
 			{
-				Flag:        "inject-session-id-on",
-				Env:         "BOUNDARY_INJECT_SESSION_ID_ON",
-				Description: `Inject target (repeatable). Requests matching these targets receive session correlation headers. Format: "domain=<host> [path=<glob>]".`,
-				Value:       &cliConfig.InjectSessionIDOn,
+				Flag:        "session-id-inject-target",
+				Env:         "BOUNDARY_SESSION_ID_INJECT_TARGET",
+				Description: `Inject target (repeatable via flag; env accepts one value). Requests matching these targets receive session correlation headers. For multiple targets use the YAML config. Format: "domain=<host> [path=<glob>]".`,
+				Value:       &cliConfig.InjectSessionIDTarget,
 				YAML:        "", // CLI only, YAML uses session_id_inject_targets.
 			},
 			{
 				Flag:        "", // No CLI flag, YAML only.
 				Description: "Inject targets from config file (YAML only).",
-				Value:       &cliConfig.InjectSessionIDOnYAML,
+				Value:       &cliConfig.InjectSessionIDTargets,
 				YAML:        "session_id_inject_targets",
 			},
 			{

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -205,22 +205,6 @@ func BaseCommand(version string) *serpent.Command {
 				Value:       &cliConfig.InjectSessionIDTargets,
 				YAML:        "session_id_inject_targets",
 			},
-			{
-				Flag:        "session-id-header-name",
-				Env:         "BOUNDARY_SESSION_ID_HEADER_NAME",
-				Description: "HTTP header name for the boundary session ID.",
-				Default:     config.DefaultSessionIDHeaderName,
-				Value:       &cliConfig.SessionIDHeaderName,
-				YAML:        "session_id_header_name",
-			},
-			{
-				Flag:        "sequence-number-header-name",
-				Env:         "BOUNDARY_SEQUENCE_NUMBER_HEADER_NAME",
-				Description: "HTTP header name for the boundary sequence number.",
-				Default:     config.DefaultSequenceNumberHeaderName,
-				Value:       &cliConfig.SequenceNumberHeaderName,
-				YAML:        "sequence_number_header_name",
-			},
 		},
 		Handler: func(inv *serpent.Invocation) error {
 			// Handle --version flag early

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -195,7 +195,7 @@ func BaseCommand(version string) *serpent.Command {
 			{
 				Flag:        "session-id-inject-target",
 				Env:         "BOUNDARY_SESSION_ID_INJECT_TARGET",
-				Description: `Inject target (repeatable via flag; env accepts one value). Requests matching these targets receive session correlation headers. For multiple targets use the YAML config. Format: "domain=<host> [path=<glob>]".`,
+				Description: `Inject target for session correlation headers. Repeat the flag once per target; each value describes exactly one target. Format: "domain=<host> [path=<glob>]". Example: --session-id-inject-target "domain=prod.coder.com path=/api/v2/aibridge/*"`,
 				Value:       &cliConfig.InjectSessionIDTarget,
 				YAML:        "", // CLI only, YAML uses session_id_inject_targets.
 			},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -169,6 +169,43 @@ func BaseCommand(version string) *serpent.Command {
 				Value:       &showVersion,
 				YAML:        "", // CLI only
 			},
+			// Session correlation header injection options.
+			{
+				Flag:        "enable-session-correlation",
+				Env:         "BOUNDARY_SESSION_CORRELATION_ENABLED",
+				Description: "Enable session correlation header injection. Disable for deployments without AI Bridge in front.",
+				Value:       &cliConfig.SessionCorrelationEnabled,
+				YAML:        "session_correlation_enabled",
+			},
+			{
+				Flag:        "inject-session-id-on",
+				Env:         "BOUNDARY_INJECT_SESSION_ID_ON",
+				Description: `Inject target (repeatable). Requests matching these targets receive session correlation headers. Format: "domain=<host> [path=<glob>]".`,
+				Value:       &cliConfig.InjectSessionIDOn,
+				YAML:        "", // CLI only, YAML uses session_id_inject_targets.
+			},
+			{
+				Flag:        "", // No CLI flag, YAML only.
+				Description: "Inject targets from config file (YAML only).",
+				Value:       &cliConfig.InjectSessionIDOnYAML,
+				YAML:        "session_id_inject_targets",
+			},
+			{
+				Flag:        "session-id-header-name",
+				Env:         "BOUNDARY_SESSION_ID_HEADER_NAME",
+				Description: "HTTP header name for the boundary session ID.",
+				Default:     config.DefaultSessionIDHeaderName,
+				Value:       &cliConfig.SessionIDHeaderName,
+				YAML:        "session_id_header_name",
+			},
+			{
+				Flag:        "sequence-number-header-name",
+				Env:         "BOUNDARY_SEQUENCE_NUMBER_HEADER_NAME",
+				Description: "HTTP header name for the boundary sequence number.",
+				Default:     config.DefaultSequenceNumberHeaderName,
+				Value:       &cliConfig.SequenceNumberHeaderName,
+				YAML:        "sequence_number_header_name",
+			},
 		},
 		Handler: func(inv *serpent.Invocation) error {
 			// Handle --version flag early

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/coder/serpent"
@@ -73,8 +74,8 @@ type CliConfig struct {
 
 	// Session correlation header injection.
 	SessionCorrelationEnabled serpent.Bool        `yaml:"session_correlation_enabled"`
-	InjectSessionIDOn         AllowStringsArray   `yaml:"inject_session_id_on"`
-	InjectSessionIDOnYAML     serpent.StringArray `yaml:"session_id_inject_targets"`
+	InjectSessionIDTarget     AllowStringsArray   `yaml:"-"`                         // From CLI flags only
+	InjectSessionIDTargets    serpent.StringArray `yaml:"session_id_inject_targets"` // From config file
 	SessionIDHeaderName       serpent.String      `yaml:"session_id_header_name"`
 	SequenceNumberHeaderName  serpent.String      `yaml:"sequence_number_header_name"`
 }
@@ -120,7 +121,7 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, er
 	userInfo := GetUserInfo()
 
 	// Build session correlation config from CLI and YAML sources.
-	sc, err := buildSessionCorrelation(cfg)
+	sc, err := buildSessionCorrelation(cfg, os.Environ())
 	if err != nil {
 		return AppConfig{}, fmt.Errorf("session correlation config: %w", err)
 	}
@@ -145,10 +146,12 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, er
 
 // buildSessionCorrelation merges CLI and YAML inject target sources,
 // parses each target string, applies header name defaults, and
-// validates the resulting configuration.
-func buildSessionCorrelation(cfg CliConfig) (SessionCorrelationConfig, error) {
+// validates the resulting configuration. environ is passed explicitly
+// (rather than reading os.Environ inside) so that callers and tests
+// can supply a controlled environment.
+func buildSessionCorrelation(cfg CliConfig, environ []string) (SessionCorrelationConfig, error) {
 	// Merge YAML targets with CLI targets.
-	rawTargets := append(cfg.InjectSessionIDOnYAML.Value(), cfg.InjectSessionIDOn.Value()...)
+	rawTargets := append(cfg.InjectSessionIDTargets.Value(), cfg.InjectSessionIDTarget.Value()...)
 
 	var targets []InjectTarget
 	for _, raw := range rawTargets {
@@ -157,6 +160,12 @@ func buildSessionCorrelation(cfg CliConfig) (SessionCorrelationConfig, error) {
 			return SessionCorrelationConfig{}, err
 		}
 		targets = append(targets, t)
+	}
+
+	if len(targets) == 0 && cfg.SessionCorrelationEnabled.Value() {
+		if t := DefaultInjectTargetFromEnv(environ); t != nil {
+			targets = []InjectTarget{*t}
+		}
 	}
 
 	// Apply defaults for header names.

--- a/config/config.go
+++ b/config/config.go
@@ -75,8 +75,6 @@ type CliConfig struct {
 	SessionCorrelationEnabled serpent.Bool        `yaml:"session_correlation_enabled"`
 	InjectSessionIDTarget     AllowStringsArray   `yaml:"-"`                         // From CLI flags only
 	InjectSessionIDTargets    serpent.StringArray `yaml:"session_id_inject_targets"` // From config file
-	SessionIDHeaderName       serpent.String      `yaml:"session_id_header_name"`
-	SequenceNumberHeaderName  serpent.String      `yaml:"sequence_number_header_name"`
 }
 
 type AppConfig struct {
@@ -144,10 +142,9 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string, environ []stri
 }
 
 // buildSessionCorrelation merges CLI and YAML inject target sources,
-// parses each target string, applies header name defaults, and
-// validates the resulting configuration. environ is passed explicitly
-// (rather than reading os.Environ inside) so that callers and tests
-// can supply a controlled environment.
+// parses each target string, and validates the resulting configuration.
+// environ is passed explicitly (rather than reading os.Environ inside)
+// so that callers and tests can supply a controlled environment.
 func buildSessionCorrelation(cfg CliConfig, environ []string) (SessionCorrelationConfig, error) {
 	// Merge YAML targets with CLI targets.
 	rawTargets := append(cfg.InjectSessionIDTargets.Value(), cfg.InjectSessionIDTarget.Value()...)
@@ -167,21 +164,9 @@ func buildSessionCorrelation(cfg CliConfig, environ []string) (SessionCorrelatio
 		}
 	}
 
-	// Apply defaults for header names.
-	sessionIDHeader := cfg.SessionIDHeaderName.Value()
-	if sessionIDHeader == "" {
-		sessionIDHeader = DefaultSessionIDHeaderName
-	}
-	seqHeader := cfg.SequenceNumberHeaderName.Value()
-	if seqHeader == "" {
-		seqHeader = DefaultSequenceNumberHeaderName
-	}
-
 	sc := SessionCorrelationConfig{
-		Enabled:                  cfg.SessionCorrelationEnabled.Value(),
-		InjectTargets:            targets,
-		SessionIDHeaderName:      sessionIDHeader,
-		SequenceNumberHeaderName: seqHeader,
+		Enabled:       cfg.SessionCorrelationEnabled.Value(),
+		InjectTargets: targets,
 	}
 
 	if err := ValidateSessionCorrelation(sc); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/coder/serpent"
@@ -105,7 +104,7 @@ type AppConfig struct {
 	SessionID uuid.UUID
 }
 
-func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, error) {
+func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string, environ []string) (AppConfig, error) {
 	// Merge allowlist from config file with allow from CLI flags
 	allowListStrings := cfg.AllowListStrings.Value()
 	allowStrings := cfg.AllowStrings.Value()
@@ -121,7 +120,7 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, er
 	userInfo := GetUserInfo()
 
 	// Build session correlation config from CLI and YAML sources.
-	sc, err := buildSessionCorrelation(cfg, os.Environ())
+	sc, err := buildSessionCorrelation(cfg, environ)
 	if err != nil {
 		return AppConfig{}, fmt.Errorf("session correlation config: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,13 @@ type CliConfig struct {
 	NoUserNamespace    serpent.Bool           `yaml:"no_user_namespace"`
 	DisableAuditLogs   serpent.Bool           `yaml:"disable_audit_logs"`
 	LogProxySocketPath serpent.String         `yaml:"log_proxy_socket_path"`
+
+	// Session correlation header injection.
+	SessionCorrelationEnabled serpent.Bool           `yaml:"session_correlation_enabled"`
+	InjectSessionIDOn         AllowStringsArray      `yaml:"inject_session_id_on"`
+	InjectSessionIDOnYAML     serpent.StringArray     `yaml:"session_id_inject_targets"`
+	SessionIDHeaderName       serpent.String          `yaml:"session_id_header_name"`
+	SequenceNumberHeaderName  serpent.String          `yaml:"sequence_number_header_name"`
 }
 
 type AppConfig struct {
@@ -86,6 +93,10 @@ type AppConfig struct {
 	UserInfo           *UserInfo
 	DisableAuditLogs   bool
 	LogProxySocketPath string
+
+	// SessionCorrelation controls header injection for AI Bridge
+	// correlation. See SessionCorrelationConfig for details.
+	SessionCorrelation SessionCorrelationConfig
 
 	// SessionID is a UUIDv4 generated at process startup. It groups
 	// all audit events produced by this boundary invocation into a
@@ -108,6 +119,12 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, er
 
 	userInfo := GetUserInfo()
 
+	// Build session correlation config from CLI and YAML sources.
+	sc, err := buildSessionCorrelation(cfg)
+	if err != nil {
+		return AppConfig{}, fmt.Errorf("session correlation config: %w", err)
+	}
+
 	return AppConfig{
 		AllowRules:         allAllowStrings,
 		LogLevel:           cfg.LogLevel.Value(),
@@ -122,5 +139,46 @@ func NewAppConfigFromCliConfig(cfg CliConfig, targetCMD []string) (AppConfig, er
 		UserInfo:           userInfo,
 		DisableAuditLogs:   cfg.DisableAuditLogs.Value(),
 		LogProxySocketPath: cfg.LogProxySocketPath.Value(),
+		SessionCorrelation: sc,
 	}, nil
+}
+
+// buildSessionCorrelation merges CLI and YAML inject target sources,
+// parses each target string, applies header name defaults, and
+// validates the resulting configuration.
+func buildSessionCorrelation(cfg CliConfig) (SessionCorrelationConfig, error) {
+	// Merge YAML targets with CLI targets.
+	rawTargets := append(cfg.InjectSessionIDOnYAML.Value(), cfg.InjectSessionIDOn.Value()...)
+
+	var targets []InjectTarget
+	for _, raw := range rawTargets {
+		t, err := ParseInjectTarget(raw)
+		if err != nil {
+			return SessionCorrelationConfig{}, err
+		}
+		targets = append(targets, t)
+	}
+
+	// Apply defaults for header names.
+	sessionIDHeader := cfg.SessionIDHeaderName.Value()
+	if sessionIDHeader == "" {
+		sessionIDHeader = DefaultSessionIDHeaderName
+	}
+	seqHeader := cfg.SequenceNumberHeaderName.Value()
+	if seqHeader == "" {
+		seqHeader = DefaultSequenceNumberHeaderName
+	}
+
+	sc := SessionCorrelationConfig{
+		Enabled:                  cfg.SessionCorrelationEnabled.Value(),
+		InjectTargets:            targets,
+		SessionIDHeaderName:      sessionIDHeader,
+		SequenceNumberHeaderName: seqHeader,
+	}
+
+	if err := ValidateSessionCorrelation(sc); err != nil {
+		return SessionCorrelationConfig{}, err
+	}
+
+	return sc, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,11 +72,11 @@ type CliConfig struct {
 	LogProxySocketPath serpent.String         `yaml:"log_proxy_socket_path"`
 
 	// Session correlation header injection.
-	SessionCorrelationEnabled serpent.Bool           `yaml:"session_correlation_enabled"`
-	InjectSessionIDOn         AllowStringsArray      `yaml:"inject_session_id_on"`
-	InjectSessionIDOnYAML     serpent.StringArray     `yaml:"session_id_inject_targets"`
-	SessionIDHeaderName       serpent.String          `yaml:"session_id_header_name"`
-	SequenceNumberHeaderName  serpent.String          `yaml:"sequence_number_header_name"`
+	SessionCorrelationEnabled serpent.Bool        `yaml:"session_correlation_enabled"`
+	InjectSessionIDOn         AllowStringsArray   `yaml:"inject_session_id_on"`
+	InjectSessionIDOnYAML     serpent.StringArray `yaml:"session_id_inject_targets"`
+	SessionIDHeaderName       serpent.String      `yaml:"session_id_header_name"`
+	SequenceNumberHeaderName  serpent.String      `yaml:"sequence_number_header_name"`
 }
 
 type AppConfig struct {

--- a/config/session_correlation.go
+++ b/config/session_correlation.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Default header names for session correlation.
+const (
+	DefaultSessionIDHeaderName      = "X-Coder-Agent-Firewall-Session-Id"
+	DefaultSequenceNumberHeaderName = "X-Coder-Agent-Firewall-Sequence-Number"
+)
+
+// InjectTarget represents a parsed target for session correlation header
+// injection. Requests matching the domain (and optional path glob) will
+// receive the session ID and sequence number headers.
+type InjectTarget struct {
+	Domain string
+	Path   string
+}
+
+// SessionCorrelationConfig holds configuration for session correlation
+// header injection. When enabled, boundary injects its session ID and
+// sequence number as custom headers on matching outbound requests so
+// that an upstream AI Bridge can correlate the request back to the
+// boundary audit event stream.
+type SessionCorrelationConfig struct {
+	// Enabled controls whether session correlation headers are injected.
+	// Deployments without AI Bridge in front should set this to false.
+	Enabled bool
+
+	// InjectTargets is the list of domain/path patterns that should
+	// receive session correlation headers.
+	InjectTargets []InjectTarget
+
+	// SessionIDHeaderName is the HTTP header name used to carry the
+	// boundary session ID. Defaults to DefaultSessionIDHeaderName.
+	SessionIDHeaderName string
+
+	// SequenceNumberHeaderName is the HTTP header name used to carry
+	// the boundary sequence number. Defaults to
+	// DefaultSequenceNumberHeaderName.
+	SequenceNumberHeaderName string
+}
+
+// ParseInjectTarget parses a string of the form "domain=... path=..."
+// into an InjectTarget. The domain key is required; path is optional.
+func ParseInjectTarget(raw string) (InjectTarget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return InjectTarget{}, fmt.Errorf("inject target must not be empty")
+	}
+
+	var target InjectTarget
+	for _, part := range strings.Fields(raw) {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return InjectTarget{}, fmt.Errorf(
+				"inject target: malformed key-value pair %q, expected key=value", part,
+			)
+		}
+		switch key {
+		case "domain":
+			if value == "" {
+				return InjectTarget{}, fmt.Errorf("inject target: domain must not be empty")
+			}
+			target.Domain = value
+		case "path":
+			target.Path = value
+		default:
+			return InjectTarget{}, fmt.Errorf("inject target: unknown key %q", key)
+		}
+	}
+
+	if target.Domain == "" {
+		return InjectTarget{}, fmt.Errorf("inject target: domain is required")
+	}
+
+	return target, nil
+}
+
+// ValidateSessionCorrelation checks that the session correlation config
+// is internally consistent. It returns an error describing the first
+// problem found, or nil if the config is valid.
+func ValidateSessionCorrelation(cfg SessionCorrelationConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if len(cfg.InjectTargets) == 0 {
+		return fmt.Errorf(
+			"session correlation is enabled but no inject targets are configured",
+		)
+	}
+
+	if cfg.SessionIDHeaderName == "" {
+		return fmt.Errorf("session-id-header-name must not be empty when session correlation is enabled")
+	}
+
+	if cfg.SequenceNumberHeaderName == "" {
+		return fmt.Errorf("sequence-number-header-name must not be empty when session correlation is enabled")
+	}
+
+	return nil
+}

--- a/config/session_correlation.go
+++ b/config/session_correlation.go
@@ -62,6 +62,7 @@ func ParseInjectTarget(raw string) (InjectTarget, error) {
 	}
 
 	var target InjectTarget
+	seen := make(map[string]bool)
 	for _, part := range strings.Fields(raw) {
 		key, value, ok := strings.Cut(part, "=")
 		if !ok {
@@ -69,6 +70,12 @@ func ParseInjectTarget(raw string) (InjectTarget, error) {
 				"inject target: malformed key-value pair %q, expected key=value", part,
 			)
 		}
+		if seen[key] {
+			return InjectTarget{}, fmt.Errorf(
+				"inject target: duplicate key %q (use separate flags for multiple targets)", key,
+			)
+		}
+		seen[key] = true
 		switch key {
 		case "domain":
 			if value == "" {

--- a/config/session_correlation.go
+++ b/config/session_correlation.go
@@ -2,13 +2,23 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
-// Default header names for session correlation.
+// Default header names and paths for session correlation.
 const (
 	DefaultSessionIDHeaderName      = "X-Coder-Agent-Firewall-Session-Id"
 	DefaultSequenceNumberHeaderName = "X-Coder-Agent-Firewall-Sequence-Number"
+
+	// DefaultAIBridgePath is the path glob used when auto-deriving an inject
+	// target from CODER_AGENT_URL.
+	DefaultAIBridgePath = "/api/v2/aibridge/*"
+
+	// CoderAgentURLEnv is the environment variable set by the Coder workspace
+	// agent that points to the control plane. Boundary uses it to derive a
+	// default inject target when none is explicitly configured.
+	CoderAgentURLEnv = "CODER_AGENT_URL"
 )
 
 // InjectTarget represents a parsed target for session correlation header
@@ -77,6 +87,38 @@ func ParseInjectTarget(raw string) (InjectTarget, error) {
 	}
 
 	return target, nil
+}
+
+// DefaultInjectTargetFromEnv derives an InjectTarget from the CODER_AGENT_URL
+// variable in the provided environment slice. It returns nil if the variable is
+// absent, empty, or not a valid URL with a host. The derived target uses
+// DefaultAIBridgePath as the path glob so that all AI Bridge traffic on the
+// control-plane host is matched.
+//
+// The environ parameter is accepted rather than reading os.Environ directly so
+// that callers (and tests) can supply an arbitrary environment.
+func DefaultInjectTargetFromEnv(environ []string) *InjectTarget {
+	var raw string
+	for _, e := range environ {
+		k, v, ok := strings.Cut(e, "=")
+		if ok && k == CoderAgentURLEnv {
+			raw = v
+			break
+		}
+	}
+	if raw == "" {
+		return nil
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return nil
+	}
+
+	return &InjectTarget{
+		Domain: u.Hostname(),
+		Path:   DefaultAIBridgePath,
+	}
 }
 
 // ValidateSessionCorrelation checks that the session correlation config

--- a/config/session_correlation.go
+++ b/config/session_correlation.go
@@ -6,10 +6,16 @@ import (
 	"strings"
 )
 
-// Default header names and paths for session correlation.
+// Header names and paths for session correlation.
 const (
-	DefaultSessionIDHeaderName      = "X-Coder-Agent-Firewall-Session-Id"
-	DefaultSequenceNumberHeaderName = "X-Coder-Agent-Firewall-Sequence-Number"
+	// SessionIDHeaderName is the fixed HTTP header name boundary injects to
+	// carry its session ID. Coder AI Gateway expects exactly this header name.
+	SessionIDHeaderName = "X-Coder-Agent-Firewall-Session-Id"
+
+	// SequenceNumberHeaderName is the fixed HTTP header name boundary injects
+	// to carry its per-session sequence number. Coder AI Gateway expects
+	// exactly this header name.
+	SequenceNumberHeaderName = "X-Coder-Agent-Firewall-Sequence-Number"
 
 	// DefaultAIBridgePath is the path glob used when auto-deriving an inject
 	// target from CODER_AGENT_URL.
@@ -42,15 +48,6 @@ type SessionCorrelationConfig struct {
 	// InjectTargets is the list of domain/path patterns that should
 	// receive session correlation headers.
 	InjectTargets []InjectTarget
-
-	// SessionIDHeaderName is the HTTP header name used to carry the
-	// boundary session ID. Defaults to DefaultSessionIDHeaderName.
-	SessionIDHeaderName string
-
-	// SequenceNumberHeaderName is the HTTP header name used to carry
-	// the boundary sequence number. Defaults to
-	// DefaultSequenceNumberHeaderName.
-	SequenceNumberHeaderName string
 }
 
 // ParseInjectTarget parses a string of the form "domain=... path=..."
@@ -140,14 +137,6 @@ func ValidateSessionCorrelation(cfg SessionCorrelationConfig) error {
 		return fmt.Errorf(
 			"session correlation is enabled but no inject targets are configured",
 		)
-	}
-
-	if cfg.SessionIDHeaderName == "" {
-		return fmt.Errorf("session-id-header-name must not be empty when session correlation is enabled")
-	}
-
-	if cfg.SequenceNumberHeaderName == "" {
-		return fmt.Errorf("sequence-number-header-name must not be empty when session correlation is enabled")
 	}
 
 	return nil

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -58,6 +58,16 @@ func TestParseInjectTarget(t *testing.T) {
 			input:   "domain=example.com port=443",
 			wantErr: true,
 		},
+		{
+			name:    "duplicate domain key",
+			input:   "domain=staging.coder.com domain=prod.coder.com",
+			wantErr: true,
+		},
+		{
+			name:    "duplicate path key",
+			input:   "domain=example.com path=/api/* path=/other/*",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -205,9 +205,9 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "enabled with inject targets",
 			cli: func() CliConfig {
-			c := baseCliConfig()
-			_ = c.SessionCorrelationEnabled.Set("true")
-			_ = c.InjectSessionIDTarget.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTarget.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
 				return c
 			}(),
 			want: SessionCorrelationConfig{
@@ -222,11 +222,11 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "custom header names",
 			cli: func() CliConfig {
-			c := baseCliConfig()
-			_ = c.SessionCorrelationEnabled.Set("true")
-			_ = c.InjectSessionIDTarget.Set("domain=example.com")
-			_ = c.SessionIDHeaderName.Set("X-My-Session")
-			_ = c.SequenceNumberHeaderName.Set("X-My-Seq")
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTarget.Set("domain=example.com")
+				_ = c.SessionIDHeaderName.Set("X-My-Session")
+				_ = c.SequenceNumberHeaderName.Set("X-My-Seq")
 				return c
 			}(),
 			want: SessionCorrelationConfig{
@@ -243,9 +243,9 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "invalid inject target",
 			cli: func() CliConfig {
-			c := baseCliConfig()
-			_ = c.SessionCorrelationEnabled.Set("true")
-			_ = c.InjectSessionIDTarget.Set("notakey")
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTarget.Set("notakey")
 				return c
 			}(),
 			wantErr: true,

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -116,60 +116,25 @@ func TestValidateSessionCorrelation(t *testing.T) {
 			},
 		},
 		{
-			name: "enabled with targets and default headers",
+			name: "enabled with targets",
 			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "dev.coder.com"}},
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
-			},
-		},
-		{
-			name: "enabled with custom headers",
-			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "example.com", Path: "/api/*"}},
-				SessionIDHeaderName:      "X-Custom-Session",
-				SequenceNumberHeaderName: "X-Custom-Seq",
+				Enabled:       true,
+				InjectTargets: []InjectTarget{{Domain: "dev.coder.com"}},
 			},
 		},
 		{
 			name: "enabled with no targets",
 			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            nil,
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+				Enabled:       true,
+				InjectTargets: nil,
 			},
 			wantErr: true,
 		},
 		{
 			name: "enabled with empty targets slice",
 			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{},
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
-			},
-			wantErr: true,
-		},
-		{
-			name: "enabled with empty session id header",
-			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
-				SessionIDHeaderName:      "",
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
-			},
-			wantErr: true,
-		},
-		{
-			name: "enabled with empty sequence number header",
-			cfg: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: "",
+				Enabled:       true,
+				InjectTargets: []InjectTarget{},
 			},
 			wantErr: true,
 		},
@@ -207,10 +172,8 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 			name: "defaults when not configured",
 			cli:  baseCliConfig(),
 			want: SessionCorrelationConfig{
-				Enabled:                  false,
-				InjectTargets:            nil,
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+				Enabled:       false,
+				InjectTargets: nil,
 			},
 		},
 		{
@@ -226,25 +189,6 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 				InjectTargets: []InjectTarget{
 					{Domain: "dev.coder.com", Path: "/api/v2/aibridge/*"},
 				},
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
-			},
-		},
-		{
-			name: "custom header names",
-			cli: func() CliConfig {
-				c := baseCliConfig()
-				_ = c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDTarget.Set("domain=example.com")
-				_ = c.SessionIDHeaderName.Set("X-My-Session")
-				_ = c.SequenceNumberHeaderName.Set("X-My-Seq")
-				return c
-			}(),
-			want: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
-				SessionIDHeaderName:      "X-My-Session",
-				SequenceNumberHeaderName: "X-My-Seq",
 			},
 		},
 		{
@@ -256,10 +200,8 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 			}(),
 			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
 			want: SessionCorrelationConfig{
-				Enabled:                  true,
-				InjectTargets:            []InjectTarget{{Domain: "dev.coder.com", Path: DefaultAIBridgePath}},
-				SessionIDHeaderName:      DefaultSessionIDHeaderName,
-				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+				Enabled:       true,
+				InjectTargets: []InjectTarget{{Domain: "dev.coder.com", Path: DefaultAIBridgePath}},
 			},
 		},
 		{
@@ -302,14 +244,6 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 			sc := got.SessionCorrelation
 			if sc.Enabled != tc.want.Enabled {
 				t.Errorf("Enabled: got %v, want %v", sc.Enabled, tc.want.Enabled)
-			}
-			if sc.SessionIDHeaderName != tc.want.SessionIDHeaderName {
-				t.Errorf("SessionIDHeaderName: got %q, want %q",
-					sc.SessionIDHeaderName, tc.want.SessionIDHeaderName)
-			}
-			if sc.SequenceNumberHeaderName != tc.want.SequenceNumberHeaderName {
-				t.Errorf("SequenceNumberHeaderName: got %q, want %q",
-					sc.SequenceNumberHeaderName, tc.want.SequenceNumberHeaderName)
 			}
 			if len(sc.InjectTargets) != len(tc.want.InjectTargets) {
 				t.Fatalf("InjectTargets len: got %d, want %d",
@@ -583,7 +517,5 @@ func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 func baseCliConfig() CliConfig {
 	c := CliConfig{}
 	_ = c.JailType.Set("nsjail")
-	_ = c.SessionIDHeaderName.Set(DefaultSessionIDHeaderName)
-	_ = c.SequenceNumberHeaderName.Set(DefaultSequenceNumberHeaderName)
 	return c
 }

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -207,7 +207,7 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 			cli: func() CliConfig {
 				c := baseCliConfig()
 				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDOn.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
+				_ = c.InjectSessionIDTarget.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
 				return c
 			}(),
 			want: SessionCorrelationConfig{
@@ -224,7 +224,7 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 			cli: func() CliConfig {
 				c := baseCliConfig()
 				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDOn.Set("domain=example.com")
+				_ = c.InjectSessionIDTarget.Set("domain=example.com")
 				c.SessionIDHeaderName.Set("X-My-Session")
 				c.SequenceNumberHeaderName.Set("X-My-Seq")
 				return c
@@ -236,21 +236,16 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 				SequenceNumberHeaderName: "X-My-Seq",
 			},
 		},
-		{
-			name: "enabled with no targets fails validation",
-			cli: func() CliConfig {
-				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
-				return c
-			}(),
-			wantErr: true,
-		},
+		// Note: "enabled with no targets" is tested in
+		// TestBuildSessionCorrelation_AgentURLFallback with a controlled
+		// environ so that CODER_AGENT_URL in the test runner's environment
+		// cannot interfere.
 		{
 			name: "invalid inject target",
 			cli: func() CliConfig {
 				c := baseCliConfig()
 				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDOn.Set("notakey")
+				_ = c.InjectSessionIDTarget.Set("notakey")
 				return c
 			}(),
 			wantErr: true,
@@ -296,6 +291,162 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 				if sc.InjectTargets[i].Path != tc.want.InjectTargets[i].Path {
 					t.Errorf("InjectTargets[%d].Path: got %q, want %q",
 						i, sc.InjectTargets[i].Path, tc.want.InjectTargets[i].Path)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultInjectTargetFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		environ []string
+		want    *InjectTarget
+	}{
+		{
+			name:    "valid URL with trailing slash",
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
+			want:    &InjectTarget{Domain: "dev.coder.com", Path: DefaultAIBridgePath},
+		},
+		{
+			name:    "valid URL without trailing slash",
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com"},
+			want:    &InjectTarget{Domain: "dev.coder.com", Path: DefaultAIBridgePath},
+		},
+		{
+			name:    "URL with port", // Ports are ignored in the rules engine, so we strip them here.
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com:8443/"},
+			want:    &InjectTarget{Domain: "dev.coder.com", Path: DefaultAIBridgePath},
+		},
+		{
+			name:    "unset variable",
+			environ: []string{},
+			want:    nil,
+		},
+		{
+			name:    "empty value",
+			environ: []string{"CODER_AGENT_URL="},
+			want:    nil,
+		},
+		{
+			name:    "no host in URL",
+			environ: []string{"CODER_AGENT_URL=not-a-url"},
+			want:    nil,
+		},
+		{
+			name:    "other env vars present but not CODER_AGENT_URL",
+			environ: []string{"CODER_URL=https://dev.coder.com/", "HOME=/home/user"},
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DefaultInjectTargetFromEnv(tc.environ)
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %+v, got nil", tc.want)
+			}
+			if got.Domain != tc.want.Domain {
+				t.Errorf("Domain: got %q, want %q", got.Domain, tc.want.Domain)
+			}
+			if got.Path != tc.want.Path {
+				t.Errorf("Path: got %q, want %q", got.Path, tc.want.Path)
+			}
+		})
+	}
+}
+
+func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         func() CliConfig
+		environ     []string
+		wantTargets []InjectTarget
+		wantErr     bool
+	}{
+		{
+			name: "enabled, no explicit targets, CODER_AGENT_URL set → auto-derived",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				return c
+			},
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
+			wantTargets: []InjectTarget{
+				{Domain: "dev.coder.com", Path: DefaultAIBridgePath},
+			},
+		},
+		{
+			name: "enabled, no explicit targets, CODER_AGENT_URL absent → error",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				return c
+			},
+			environ: []string{},
+			wantErr: true,
+		},
+		{
+			name: "enabled, explicit target wins over CODER_AGENT_URL",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTarget.Set("domain=custom.example.com")
+				return c
+			},
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
+			wantTargets: []InjectTarget{
+				{Domain: "custom.example.com", Path: ""},
+			},
+		},
+		{
+			name: "disabled, CODER_AGENT_URL absent → valid (no targets needed)",
+			cfg: func() CliConfig {
+				return baseCliConfig()
+			},
+			environ:     []string{},
+			wantTargets: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sc, err := buildSessionCorrelation(tc.cfg(), tc.environ)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(sc.InjectTargets) != len(tc.wantTargets) {
+				t.Fatalf("InjectTargets len: got %d, want %d",
+					len(sc.InjectTargets), len(tc.wantTargets))
+			}
+			for i := range sc.InjectTargets {
+				if sc.InjectTargets[i].Domain != tc.wantTargets[i].Domain {
+					t.Errorf("InjectTargets[%d].Domain: got %q, want %q",
+						i, sc.InjectTargets[i].Domain, tc.wantTargets[i].Domain)
+				}
+				if sc.InjectTargets[i].Path != tc.wantTargets[i].Path {
+					t.Errorf("InjectTargets[%d].Path: got %q, want %q",
+						i, sc.InjectTargets[i].Path, tc.wantTargets[i].Path)
 				}
 			}
 		})

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -205,9 +205,9 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "enabled with inject targets",
 			cli: func() CliConfig {
-				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDTarget.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
+			c := baseCliConfig()
+			_ = c.SessionCorrelationEnabled.Set("true")
+			_ = c.InjectSessionIDTarget.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
 				return c
 			}(),
 			want: SessionCorrelationConfig{
@@ -222,11 +222,11 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "custom header names",
 			cli: func() CliConfig {
-				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDTarget.Set("domain=example.com")
-				c.SessionIDHeaderName.Set("X-My-Session")
-				c.SequenceNumberHeaderName.Set("X-My-Seq")
+			c := baseCliConfig()
+			_ = c.SessionCorrelationEnabled.Set("true")
+			_ = c.InjectSessionIDTarget.Set("domain=example.com")
+			_ = c.SessionIDHeaderName.Set("X-My-Session")
+			_ = c.SequenceNumberHeaderName.Set("X-My-Seq")
 				return c
 			}(),
 			want: SessionCorrelationConfig{
@@ -243,9 +243,9 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		{
 			name: "invalid inject target",
 			cli: func() CliConfig {
-				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
-				_ = c.InjectSessionIDTarget.Set("notakey")
+			c := baseCliConfig()
+			_ = c.SessionCorrelationEnabled.Set("true")
+			_ = c.InjectSessionIDTarget.Set("notakey")
 				return c
 			}(),
 			wantErr: true,
@@ -380,7 +380,7 @@ func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 			name: "enabled, no explicit targets, CODER_AGENT_URL set → auto-derived",
 			cfg: func() CliConfig {
 				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
+				_ = c.SessionCorrelationEnabled.Set("true")
 				return c
 			},
 			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
@@ -392,7 +392,7 @@ func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 			name: "enabled, no explicit targets, CODER_AGENT_URL absent → error",
 			cfg: func() CliConfig {
 				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
+				_ = c.SessionCorrelationEnabled.Set("true")
 				return c
 			},
 			environ: []string{},
@@ -402,7 +402,7 @@ func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 			name: "enabled, explicit target wins over CODER_AGENT_URL",
 			cfg: func() CliConfig {
 				c := baseCliConfig()
-				c.SessionCorrelationEnabled.Set("true")
+				_ = c.SessionCorrelationEnabled.Set("true")
 				_ = c.InjectSessionIDTarget.Set("domain=custom.example.com")
 				return c
 			},
@@ -458,8 +458,8 @@ func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 // correlation fields without tripping over unrelated validation.
 func baseCliConfig() CliConfig {
 	c := CliConfig{}
-	c.JailType.Set("nsjail")
-	c.SessionIDHeaderName.Set(DefaultSessionIDHeaderName)
-	c.SequenceNumberHeaderName.Set(DefaultSequenceNumberHeaderName)
+	_ = c.JailType.Set("nsjail")
+	_ = c.SessionIDHeaderName.Set(DefaultSessionIDHeaderName)
+	_ = c.SequenceNumberHeaderName.Set(DefaultSequenceNumberHeaderName)
 	return c
 }

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -1,0 +1,314 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseInjectTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    InjectTarget
+		wantErr bool
+	}{
+		{
+			name:  "domain only",
+			input: "domain=dev.coder.com",
+			want:  InjectTarget{Domain: "dev.coder.com"},
+		},
+		{
+			name:  "domain and path",
+			input: "domain=dev.coder.com path=/api/v2/aibridge/*",
+			want:  InjectTarget{Domain: "dev.coder.com", Path: "/api/v2/aibridge/*"},
+		},
+		{
+			name:  "leading and trailing whitespace",
+			input: "  domain=dev.coder.com path=/api/* ",
+			want:  InjectTarget{Domain: "dev.coder.com", Path: "/api/*"},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "missing domain",
+			input:   "path=/api/*",
+			wantErr: true,
+		},
+		{
+			name:    "empty domain value",
+			input:   "domain=",
+			wantErr: true,
+		},
+		{
+			name:    "malformed pair no equals",
+			input:   "domain",
+			wantErr: true,
+		},
+		{
+			name:    "unknown key",
+			input:   "domain=example.com port=443",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseInjectTarget(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Domain != tc.want.Domain {
+				t.Errorf("Domain: got %q, want %q", got.Domain, tc.want.Domain)
+			}
+			if got.Path != tc.want.Path {
+				t.Errorf("Path: got %q, want %q", got.Path, tc.want.Path)
+			}
+		})
+	}
+}
+
+func TestValidateSessionCorrelation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     SessionCorrelationConfig
+		wantErr bool
+	}{
+		{
+			name: "disabled is always valid",
+			cfg: SessionCorrelationConfig{
+				Enabled: false,
+			},
+		},
+		{
+			name: "disabled with empty targets is valid",
+			cfg: SessionCorrelationConfig{
+				Enabled:       false,
+				InjectTargets: nil,
+			},
+		},
+		{
+			name: "enabled with targets and default headers",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "dev.coder.com"}},
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+		},
+		{
+			name: "enabled with custom headers",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "example.com", Path: "/api/*"}},
+				SessionIDHeaderName:      "X-Custom-Session",
+				SequenceNumberHeaderName: "X-Custom-Seq",
+			},
+		},
+		{
+			name: "enabled with no targets",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            nil,
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled with empty targets slice",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{},
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled with empty session id header",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
+				SessionIDHeaderName:      "",
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled with empty sequence number header",
+			cfg: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateSessionCorrelation(tc.cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cli     CliConfig
+		want    SessionCorrelationConfig
+		wantErr bool
+	}{
+		{
+			name: "defaults when not configured",
+			cli:  baseCliConfig(),
+			want: SessionCorrelationConfig{
+				Enabled:                  false,
+				InjectTargets:            nil,
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+		},
+		{
+			name: "enabled with inject targets",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDOn.Set("domain=dev.coder.com path=/api/v2/aibridge/*")
+				return c
+			}(),
+			want: SessionCorrelationConfig{
+				Enabled: true,
+				InjectTargets: []InjectTarget{
+					{Domain: "dev.coder.com", Path: "/api/v2/aibridge/*"},
+				},
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+		},
+		{
+			name: "custom header names",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDOn.Set("domain=example.com")
+				c.SessionIDHeaderName.Set("X-My-Session")
+				c.SequenceNumberHeaderName.Set("X-My-Seq")
+				return c
+			}(),
+			want: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "example.com"}},
+				SessionIDHeaderName:      "X-My-Session",
+				SequenceNumberHeaderName: "X-My-Seq",
+			},
+		},
+		{
+			name: "enabled with no targets fails validation",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "invalid inject target",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDOn.Set("notakey")
+				return c
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewAppConfigFromCliConfig(tc.cli, []string{"echo", "hello"})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			sc := got.SessionCorrelation
+			if sc.Enabled != tc.want.Enabled {
+				t.Errorf("Enabled: got %v, want %v", sc.Enabled, tc.want.Enabled)
+			}
+			if sc.SessionIDHeaderName != tc.want.SessionIDHeaderName {
+				t.Errorf("SessionIDHeaderName: got %q, want %q",
+					sc.SessionIDHeaderName, tc.want.SessionIDHeaderName)
+			}
+			if sc.SequenceNumberHeaderName != tc.want.SequenceNumberHeaderName {
+				t.Errorf("SequenceNumberHeaderName: got %q, want %q",
+					sc.SequenceNumberHeaderName, tc.want.SequenceNumberHeaderName)
+			}
+			if len(sc.InjectTargets) != len(tc.want.InjectTargets) {
+				t.Fatalf("InjectTargets len: got %d, want %d",
+					len(sc.InjectTargets), len(tc.want.InjectTargets))
+			}
+			for i := range sc.InjectTargets {
+				if sc.InjectTargets[i].Domain != tc.want.InjectTargets[i].Domain {
+					t.Errorf("InjectTargets[%d].Domain: got %q, want %q",
+						i, sc.InjectTargets[i].Domain, tc.want.InjectTargets[i].Domain)
+				}
+				if sc.InjectTargets[i].Path != tc.want.InjectTargets[i].Path {
+					t.Errorf("InjectTargets[%d].Path: got %q, want %q",
+						i, sc.InjectTargets[i].Path, tc.want.InjectTargets[i].Path)
+				}
+			}
+		})
+	}
+}
+
+// baseCliConfig returns a CliConfig with valid defaults for fields that
+// NewAppConfigFromCliConfig requires, so tests can focus on the session
+// correlation fields without tripping over unrelated validation.
+func baseCliConfig() CliConfig {
+	c := CliConfig{}
+	c.JailType.Set("nsjail")
+	c.SessionIDHeaderName.Set(DefaultSessionIDHeaderName)
+	c.SequenceNumberHeaderName.Set(DefaultSequenceNumberHeaderName)
+	return c
+}

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -398,6 +398,98 @@ func TestDefaultInjectTargetFromEnv(t *testing.T) {
 	}
 }
 
+func TestBuildSessionCorrelation_TargetMerge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         func() CliConfig
+		wantTargets []InjectTarget
+	}{
+		{
+			name: "YAML targets only",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTargets.Set("domain=yaml.example.com path=/yaml/*")
+				return c
+			},
+			wantTargets: []InjectTarget{
+				{Domain: "yaml.example.com", Path: "/yaml/*"},
+			},
+		},
+		{
+			name: "CLI targets only",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTarget.Set("domain=cli.example.com path=/cli/*")
+				return c
+			},
+			wantTargets: []InjectTarget{
+				{Domain: "cli.example.com", Path: "/cli/*"},
+			},
+		},
+		{
+			name: "YAML and CLI targets merged, YAML comes first",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTargets.Set("domain=yaml.example.com path=/yaml/*")
+				_ = c.InjectSessionIDTarget.Set("domain=cli.example.com path=/cli/*")
+				return c
+			},
+			wantTargets: []InjectTarget{
+				{Domain: "yaml.example.com", Path: "/yaml/*"},
+				{Domain: "cli.example.com", Path: "/cli/*"},
+			},
+		},
+		{
+			name: "multiple from each source are all preserved",
+			cfg: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				_ = c.InjectSessionIDTargets.Set("domain=yaml1.example.com")
+				_ = c.InjectSessionIDTargets.Set("domain=yaml2.example.com")
+				_ = c.InjectSessionIDTarget.Set("domain=cli1.example.com")
+				_ = c.InjectSessionIDTarget.Set("domain=cli2.example.com")
+				return c
+			},
+			wantTargets: []InjectTarget{
+				{Domain: "yaml1.example.com"},
+				{Domain: "yaml2.example.com"},
+				{Domain: "cli1.example.com"},
+				{Domain: "cli2.example.com"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sc, err := buildSessionCorrelation(tc.cfg(), []string{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(sc.InjectTargets) != len(tc.wantTargets) {
+				t.Fatalf("InjectTargets len: got %d, want %d",
+					len(sc.InjectTargets), len(tc.wantTargets))
+			}
+			for i := range sc.InjectTargets {
+				if sc.InjectTargets[i].Domain != tc.wantTargets[i].Domain {
+					t.Errorf("InjectTargets[%d].Domain: got %q, want %q",
+						i, sc.InjectTargets[i].Domain, tc.wantTargets[i].Domain)
+				}
+				if sc.InjectTargets[i].Path != tc.wantTargets[i].Path {
+					t.Errorf("InjectTargets[%d].Path: got %q, want %q",
+						i, sc.InjectTargets[i].Path, tc.wantTargets[i].Path)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildSessionCorrelation_AgentURLFallback(t *testing.T) {
 	t.Parallel()
 

--- a/config/session_correlation_test.go
+++ b/config/session_correlation_test.go
@@ -189,6 +189,7 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 	tests := []struct {
 		name    string
 		cli     CliConfig
+		environ []string
 		want    SessionCorrelationConfig
 		wantErr bool
 	}{
@@ -236,10 +237,31 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 				SequenceNumberHeaderName: "X-My-Seq",
 			},
 		},
-		// Note: "enabled with no targets" is tested in
-		// TestBuildSessionCorrelation_AgentURLFallback with a controlled
-		// environ so that CODER_AGENT_URL in the test runner's environment
-		// cannot interfere.
+		{
+			name: "enabled with no targets, CODER_AGENT_URL set → auto-derived",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				return c
+			}(),
+			environ: []string{"CODER_AGENT_URL=https://dev.coder.com/"},
+			want: SessionCorrelationConfig{
+				Enabled:                  true,
+				InjectTargets:            []InjectTarget{{Domain: "dev.coder.com", Path: DefaultAIBridgePath}},
+				SessionIDHeaderName:      DefaultSessionIDHeaderName,
+				SequenceNumberHeaderName: DefaultSequenceNumberHeaderName,
+			},
+		},
+		{
+			name: "enabled with no targets, CODER_AGENT_URL absent → error",
+			cli: func() CliConfig {
+				c := baseCliConfig()
+				_ = c.SessionCorrelationEnabled.Set("true")
+				return c
+			}(),
+			environ: []string{},
+			wantErr: true,
+		},
 		{
 			name: "invalid inject target",
 			cli: func() CliConfig {
@@ -256,7 +278,7 @@ func TestNewAppConfigFromCliConfig_SessionCorrelation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := NewAppConfigFromCliConfig(tc.cli, []string{"echo", "hello"})
+			got, err := NewAppConfigFromCliConfig(tc.cli, []string{"echo", "hello"}, tc.environ)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")


### PR DESCRIPTION
## PR Map

1. #196
2. 👉🏼 **#197**
3. #198

---

RFC: [Bridge ↔ Boundaries Correlation](https://www.notion.so/Bridge-Boundaries-Correlation-313d579be59281f3b4efdbfd6896775a)

Add YAML and CLI configuration surface for session correlation header injection per FR 2 of the RFC.

Depends on #196.

## Changes

- **`config/session_correlation.go`**: New file. Defines `SessionCorrelationConfig`, `InjectTarget`, `ParseInjectTarget` (with duplicate-key detection), `ValidateSessionCorrelation`, fixed header name constants (`SessionIDHeaderName`, `SequenceNumberHeaderName`), and `DefaultInjectTargetFromEnv` — a helper that derives a default inject target from `CODER_AGENT_URL` when no explicit targets are configured.
- **`config/session_correlation_test.go`**: New file. Table-driven tests for `ParseInjectTarget` (including duplicate-key rejection), `ValidateSessionCorrelation`, the end-to-end `NewAppConfigFromCliConfig` session correlation path (with controlled `environ`), `DefaultInjectTargetFromEnv`, CLI+YAML target merging (`TestBuildSessionCorrelation_TargetMerge`), and the `CODER_AGENT_URL` fallback path (`TestBuildSessionCorrelation_AgentURLFallback`).
- **`config/config.go`**: Wire session correlation fields into `CliConfig` (three new fields for serpent bindings: `SessionCorrelationEnabled`, `InjectSessionIDTarget`, `InjectSessionIDTargets`) and `AppConfig` (new `SessionCorrelation` field). `NewAppConfigFromCliConfig` now accepts an `environ []string` parameter so the `CODER_AGENT_URL` fallback is testable without relying on the host environment. Add `buildSessionCorrelation` helper that merges YAML+CLI inject targets, falls back to a target derived from `CODER_AGENT_URL` when none are configured and session correlation is enabled, and validates the result.
- **`cli/cli.go`**: Register three new serpent options, pass `os.Environ()` to `NewAppConfigFromCliConfig`, and add usage examples including a zero-config workspace example.

## New CLI flags

| Flag | Env | YAML | Default | Description |
|---|---|---|---|---|
| `--enable-session-correlation` | `BOUNDARY_SESSION_CORRELATION_ENABLED` | `session_correlation_enabled` | `false` | Toggle; when enabled with no explicit targets, the inject target is auto-derived from `CODER_AGENT_URL` (set automatically in Coder workspaces) |
| `--session-id-inject-target` | `BOUNDARY_SESSION_ID_INJECT_TARGET` | — | — | Repeatable inject target (one target per flag invocation; env accepts one value; use YAML for multiple). Format: `domain=<host> [path=<glob>]` |
| — | — | `session_id_inject_targets` | — | YAML-only list of inject targets |

Header names are fixed constants (`X-Coder-Agent-Firewall-Session-Id`, `X-Coder-Agent-Firewall-Sequence-Number`) matching what Coder AI Gateway expects — they are not user-configurable.

Config validation ensures that when correlation is enabled at least one inject target is present (either explicit or auto-derived from `CODER_AGENT_URL`). Parsing validates the `domain=... path=...` key-value format, rejects unknown keys, and rejects duplicate keys within a single target string.

This commit adds config and validation only; runtime injection is wired in a follow-up PR.

> [!NOTE]
> This PR was authored by Coder Agents.